### PR TITLE
Fixed: Tokenizer Errors

### DIFF
--- a/lua/expression3/tokenizer.lua
+++ b/lua/expression3/tokenizer.lua
@@ -180,7 +180,7 @@ end
 
 function TOKENIZER.Throw(this, offset, msg, fst, ...)
 	if this.etokens then
-		this:NextPattern("^.-\n")) then
+		this:NextPattern("^.-\n");
 		this:CreateToken("err", "error");
 	end
 


### PR DESCRIPTION
Fixed the error that i can't open expadv3, because of the tokenizer printing errors in the console