### PR TITLE
fixed wireOutput assignment on dupe paste

### DIFF
--- a/lua/entities/wire_expression3_base/init.lua
+++ b/lua/entities/wire_expression3_base/init.lua
@@ -155,8 +155,7 @@ function ENT:BuildWiredPorts(sort_in, sort_out)
 		local port = self.wire_outport_tbl[name];
 
 		if (port and port.wire == wireport.Type) then
-			local value = wireport.Value;
-			context.wire_out[name] = port.func_in and port.func_in(value) or value;
+			self:TriggerOutput(name, wireport.Value, true);
 		end
 	end
 


### PR DESCRIPTION
What was the reason for the former code here? Pasting dupes didn't work because at the time of pasting the context is nil. Changing it to `self:TriggerOutput` fixes the issue.