### PR TITLE
Add text alignment parameter to drawText

### DIFF
--- a/lua/expression3/extensions/render.lua
+++ b/lua/expression3/extensions/render.lua
@@ -320,6 +320,14 @@ extension:RegisterFunction("render", "drawText", "v2,s", "n", 2, function(ctx, p
 	surface.DrawText(str);
 end, false);
 
+extension:RegisterFunction("render", "drawText", "v2,s,n", "n", 2, function(ctx, p, str, align)
+	surface.SetFont(FONT);
+	local width, _ = surface.GetTextSize(str);
+	preDraw(ctx);
+	surface.SetTextPos(p.x-width*align/2, p.y);
+	surface.DrawText(str);
+end, false);
+
 --[[
 	*****************************************************************************************************************************************************
 		HUD


### PR DESCRIPTION
This overloads the method `render.drawText` adding the possibility to align the text (left: 0, center: 1, right: 2).